### PR TITLE
Fix projectile stuttering.

### DIFF
--- a/AngryPythons.pyw
+++ b/AngryPythons.pyw
@@ -34,7 +34,7 @@ MENU_COLUMN_NUMBER = 4
 # Program entry point, opens window and displays options menu
 def main(width, height):
 
-    win = GraphWin("PyBirds", width, height)
+    win = GraphWin("PyBirds", width, height, autoflush=False)
     menuInputs = intialiseMenuInputs()
     while True:
         menuInputs = menu(win, menuInputs)

--- a/physics.py
+++ b/physics.py
@@ -92,6 +92,7 @@ def simulateProjectile(win, start, clickPos, obstacles, targets, physicsConstant
             sleepTime = tickLength - elapsedTime
             time.sleep(sleepTime) # Wait before next step
         lastTick = time.time()
+        win.flush()
 
     # => Projectile out of bounds (off-screen)
     projectile.undraw()


### PR DESCRIPTION
This Pull Request simply disables the autoflush feature which is enabled by default in the window. The window is then flushed after the projectile has been moved.

An alternative fix would be to not create a new projectile circle every tick, and instead move the existing one but I found it to be a little more cumbersome relative to the existing codebase.